### PR TITLE
add build platform to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:20.04
 
+ARG BUILDPLATFORM=linux/x86_64
+
 ENV ARGS=""
 
 RUN apt update
@@ -14,7 +16,7 @@ RUN curl -OL https://github.com/LimeChain/matchstick/releases/download/0.2.2/bin
 RUN chmod a+x binary-linux-20
 
 RUN mkdir matchstick
-WORKDIR matchstick
+WORKDIR /matchstick
 
 COPY ../ .
 


### PR DESCRIPTION
- prevents CLI error `/bin/sh: 1: ./binary-linux-20: not found` when running `docker run --rm matchstick` post build
- additionally prepended working directory with forward slash to resolve dockerfile-utils absolute path warning